### PR TITLE
Add a check for DCN 3.5.0 DMCUB microcode version

### DIFF
--- a/src/amd_debug/common.py
+++ b/src/amd_debug/common.py
@@ -278,6 +278,20 @@ def get_property_pyudev(properties, key, fallback=""):
         return ""
 
 
+def find_ip_version(base_path, kind, hw_ver) -> bool:
+    """Determine if an IP version is present on the system"""
+    b = os.path.join(base_path, "ip_discovery", "die", "0", kind, "0")
+    for key, expected_value in hw_ver.items():
+        p = os.path.join(b, key)
+        if not os.path.exists(p):
+            continue
+        v = int(read_file(p))
+        if v != expected_value:
+            continue
+        return True
+    return False
+
+
 def read_msr(msr, cpu):
     """Read a Model-Specific Register (MSR) value from the CPU."""
     p = f"/dev/cpu/{cpu}/msr"

--- a/src/amd_debug/failures.py
+++ b/src/amd_debug/failures.py
@@ -586,3 +586,15 @@ class RogAllyMcuPowerSave(S0i3Failure):
             "The MCU powersave feature is disabled which will cause problems "
             "with the controller after suspend/resume."
         )
+
+
+class DmcubTooOld(S0i3Failure):
+    """DMCUB microcode is too old"""
+
+    def __init__(self, current, expected):
+        super().__init__()
+        self.description = "DMCUB microcode is too old"
+        self.explanation = (
+            f"The DMCUB microcode version {hex(current)} is older than the"
+            f"minimum suggested version {hex(expected)}."
+        )


### PR DESCRIPTION
On DCN 3.5.0 if DMCUB version is less than 0x09001B00 systems without USB4 routers may not be able to get into IPS.  IPS is a requirement for s0i3, so check for the combination.