### PR TITLE
Fix: binaries now exit with status code 0 on success

### DIFF
--- a/src/amd_debug/__init__.py
+++ b/src/amd_debug/__init__.py
@@ -42,4 +42,4 @@ def launch_tool(tool_name):
         return tools[tool_name]()
     else:
         print(f"\033[91mUnknown exe: {tool_name}\033[0m")
-        return False
+        return 1

--- a/src/amd_debug/bios.py
+++ b/src/amd_debug/bios.py
@@ -122,7 +122,7 @@ def parse_args():
     return args
 
 
-def main():
+def main() -> None|int:
     """Main function"""
     args = parse_args()
     ret = False
@@ -135,4 +135,6 @@ def main():
     elif args.command == "version":
         print(version())
     show_log_info()
-    return ret
+    if ret is False:
+        return 1
+    return

--- a/src/amd_debug/installer.py
+++ b/src/amd_debug/installer.py
@@ -446,7 +446,7 @@ def parse_args():
     return parser.parse_args()
 
 
-def install_dep_superset() -> bool:
+def install_dep_superset() -> None|int:
     """Install all python supserset dependencies"""
     args = parse_args()
     tool = Installer(tool_debug=args.tool_debug)
@@ -465,4 +465,6 @@ def install_dep_superset() -> bool:
     if ret:
         print_color("All dependencies installed", "✅")
     show_log_info()
-    return ret
+    if ret is False:
+        return 1
+    return

--- a/src/amd_debug/pstate.py
+++ b/src/amd_debug/pstate.py
@@ -300,15 +300,17 @@ def parse_args():
     return parser.parse_args()
 
 
-def main():
+def main() -> None|int:
     """Main function"""
     args = parse_args()
     ret = False
     if args.command == "version":
         print(version())
-        return True
+        return
     elif args.command == "triage":
         triage = AmdPstateTriage(args.tool_debug)
         ret = triage.run()
     show_log_info()
-    return ret
+    if ret is False:
+        return 1
+    return

--- a/src/amd_debug/s2idle.py
+++ b/src/amd_debug/s2idle.py
@@ -394,7 +394,7 @@ def parse_args():
     return parser.parse_args()
 
 
-def main():
+def main() -> None|int:
     """Main function"""
     args = parse_args()
     ret = False
@@ -429,8 +429,10 @@ def main():
         )
     elif args.action == "version":
         print(version())
-        return True
+        return
     else:
         sys.exit("no action specified")
     show_log_info()
-    return ret
+    if ret is False:
+        return 1
+    return

--- a/src/launcher.py
+++ b/src/launcher.py
@@ -28,7 +28,6 @@ def main():
             f"Missing dependency: {e}\n"
             f"Run ./install_deps.py to install dependencies."
         )
-        return False
 
 
 if __name__ == "__main__":

--- a/src/test_bios.py
+++ b/src/test_bios.py
@@ -194,7 +194,7 @@ class TestAmdBios(unittest.TestCase):
         mock_amd_bios.assert_called_once_with(None, True)
         mock_app.set_tracing.assert_called_once_with(True)
         mock_show_log_info.assert_called_once()
-        self.assertTrue(result)
+        self.assertIsNone(result)
 
     @patch("amd_debug.bios.AmdBios")
     @patch("amd_debug.bios.parse_args")
@@ -217,7 +217,7 @@ class TestAmdBios(unittest.TestCase):
         mock_amd_bios.assert_called_once_with("test.log", True)
         mock_app.run.assert_called_once()
         mock_show_log_info.assert_called_once()
-        self.assertTrue(result)
+        self.assertIsNone(result)
 
     @patch("amd_debug.bios.parse_args")
     @patch("amd_debug.bios.version")
@@ -235,7 +235,7 @@ class TestAmdBios(unittest.TestCase):
         mock_parse_args.assert_called_once()
         mock_version.assert_called_once()
         mock_show_log_info.assert_called_once()
-        self.assertEqual(result, False)
+        self.assertEqual(result, 1)
 
     @patch("amd_debug.bios.parse_args")
     @patch("amd_debug.bios.show_log_info")
@@ -247,4 +247,4 @@ class TestAmdBios(unittest.TestCase):
 
         mock_parse_args.assert_called_once()
         mock_show_log_info.assert_called_once()
-        self.assertFalse(result)
+        self.assertEqual(result, 1)

--- a/src/test_launcher.py
+++ b/src/test_launcher.py
@@ -26,10 +26,11 @@ class TestLauncher(unittest.TestCase):
         """Test launching as unknown exe"""
 
         with patch("builtins.print") as mock_print:
-            amd_debug.launch_tool("unknown_exe.py")
+            result = amd_debug.launch_tool("unknown_exe.py")
             mock_print.assert_called_once_with(
                 "\033[91mUnknown exe: unknown_exe.py\033[0m"
             )
+            self.assertIsNotNone(result)
 
     def test_launcher_amd_s2idle(self):
         """Test launching amd_s2idle"""

--- a/src/test_s2idle.py
+++ b/src/test_s2idle.py
@@ -180,7 +180,7 @@ class TestMainFunction(unittest.TestCase):
             mock_report.assert_called_once_with(
                 "2023-01-01", "2023-02-01", None, "html", False, False
             )
-            self.assertTrue(result)
+            self.assertIsNone(result)
 
     @patch("amd_debug.s2idle.relaunch_sudo")
     @patch("amd_debug.s2idle.run_test_cycle")
@@ -207,7 +207,7 @@ class TestMainFunction(unittest.TestCase):
             mock_test.assert_called_once_with(
                 None, None, "5", "txt", None, False, False, False, False, False
             )
-            self.assertTrue(result)
+            self.assertIsNone(result)
 
     @patch("amd_debug.s2idle.version")
     def test_main_version(self, mock_version):
@@ -220,7 +220,7 @@ class TestMainFunction(unittest.TestCase):
                 result = main()
                 mock_version.assert_called_once()
                 mock_print.assert_called_once_with("1.0.0")
-                self.assertTrue(result)
+                self.assertIsNone(result)
 
     def test_main_no_action(self):
         """Test main function with no action specified"""


### PR DESCRIPTION
Fixes #4

This fixes the problem by only modifying the `main` fuctions (and `install_dep_superset`). One could also change *all* other functions that return `True`/`False` to return `None` / Value containing error information, but that would be a lot of work for little gain IMO.