### PR TITLE
s2idle: fix quote reuse inside f-string for older python versions

### DIFF
--- a/src/amd_debug/s2idle.py
+++ b/src/amd_debug/s2idle.py
@@ -120,7 +120,7 @@ def prompt_report_arguments(since, until, fname, fmt, report_debug) -> str:
     if report_debug is None:
         inp = (
             input(
-                f"{Headers.ReportDebugDescription} ({colorize_choices(Defaults.boolean_choices, "true")})? "
+                f"{Headers.ReportDebugDescription} ({colorize_choices(Defaults.boolean_choices, 'true')})? "
             )
             .lower()
             .capitalize()


### PR DESCRIPTION
This feature was only added in version 3.12 ([PEP701](https://docs.python.org/3.12/whatsnew/3.12.html#whatsnew312-pep701))