### PR TITLE
prerequisites: check_fadt now catches FileNotFoundError for FACP

### DIFF
--- a/src/amd_debug/prerequisites.py
+++ b/src/amd_debug/prerequisites.py
@@ -595,6 +595,9 @@ class PrerequisiteValidator(AmdTool):
                 with open(target, "rb") as r:
                     r.seek(0x70)
                     found = struct.unpack("<I", r.read(4))[0] & BIT(21)
+            except FileNotFoundError:
+                self.db.record_prereq("FADT check unavailable", "🚦")
+                return True
             except PermissionError:
                 self.db.record_prereq("FADT check unavailable", "🚦")
                 return True

--- a/src/test_prerequisites.py
+++ b/src/test_prerequisites.py
@@ -798,8 +798,7 @@ class TestPrerequisiteValidator(unittest.TestCase):
         self.assertFalse(result)
         self.assertTrue(any(isinstance(f, FadtWrong) for f in self.validator.failures))
 
-    @patch("amd_debug.prerequisites.os.path.exists", return_value=False)
-    def test_check_fadt_file_not_found(self, mock_path_exists):
+    def test_check_fadt_file_not_found(self):
         """Test check_fadt when FADT file is not found"""
         self.mock_kernel_log.match_line.return_value = False
         result = self.validator.check_fadt()


### PR DESCRIPTION
I noticed the `test_check_fadt_file_not_found` test actually **failes** when `/sys/firmware/acpi/tables/FACP` does not exist. Outside of the test environment this *should* result in crash of the program.