### PR TITLE
Fix f-string in explanation for IOMMU ACPI failures

### DIFF
--- a/src/amd_debug/failures.py
+++ b/src/amd_debug/failures.py
@@ -467,7 +467,7 @@ class MissingIommuACPI(S0i3Failure):
         super().__init__()
         self.description = f"Device {device} missing from ACPI tables"
         self.explanation = (
-            "The ACPI device {device} is required for suspend to work when the IOMMU is enabled. "
+            f"The ACPI device {device} is required for suspend to work when the IOMMU is enabled. "
             "Please check your BIOS settings and if configured correctly, report a bug to your system vendor."
         )
         self.url = "https://gitlab.freedesktop.org/drm/amd/-/issues/3738#note_2667140"


### PR DESCRIPTION
Was just missing the `f` prefix.