### PR TITLE
s2idle-hook: Support suspend-then-hibernate mode

### DIFF
--- a/src/amd_debug/s2idle-hook
+++ b/src/amd_debug/s2idle-hook
@@ -3,6 +3,7 @@
 
 import argparse
 import logging
+import os
 import sys
 
 
@@ -59,7 +60,10 @@ def parse_args():
 if __name__ == "__main__":
     args = parse_args()
 
-    if args.mode != "suspend":
+    if (
+        args.mode != "suspend"
+        and not os.getenv("SYSTEMD_SLEEP_ACTION", "").startswith("suspend")
+    ):
         sys.exit(0)
 
     if args.path:


### PR DESCRIPTION
If the SYSTEMD_SLEEP_ACTION environment variable is set (v248+) check it for "suspend" / "suspend-after-failed-hibernate" in addition to args.mode == "suspend" when deciding whether to record a cycle.

Fixes #26