### PR TITLE
Carry XDG_DATA_DIRS across sudo

### DIFF
--- a/src/amd_debug/common.py
+++ b/src/amd_debug/common.py
@@ -392,6 +392,7 @@ def relaunch_sudo() -> None:
             "XDG_RUNTIME_DIR",
             "DBUS_SESSION_BUS_ADDRESS",
             "XDG_SESSION_TYPE",
+            "XDG_DATA_DIRS"
         ]:
             value = os.environ.get(var)
             if value:

--- a/src/amd_debug/s2idle.py
+++ b/src/amd_debug/s2idle.py
@@ -62,7 +62,7 @@ def display_report_file(fname, fmt) -> None:
     if user:
         env_vars = []
         for var in ["DISPLAY", "WAYLAND_DISPLAY", "XAUTHORITY", "XDG_RUNTIME_DIR",
-                    "DBUS_SESSION_BUS_ADDRESS", "XDG_SESSION_TYPE"]:
+                    "DBUS_SESSION_BUS_ADDRESS", "XDG_SESSION_TYPE", "XDG_DATA_DIRS"]:
             value = os.environ.get(var)
             if value:
                 env_vars.append(f"{var}={value}")


### PR DESCRIPTION
After 91f03b0 ("Only take env variables needed for `sudo`"), `amd_s2idle.py` no longer launch Firefox for showing an HTML report after a test. This is due to missing env variables when searching for preferred applications. Pass the XDG_DATA_DIRS env variable across sudo to fix this behavior.

This has been tested on Noble, Questing, and today's Resolute daily build image.