### PR TITLE
Make NPU failures non-fatal

### DIFF
--- a/src/amd_debug/prerequisites.py
+++ b/src/amd_debug/prerequisites.py
@@ -352,7 +352,6 @@ class PrerequisiteValidator(AmdTool):
             if not driver:
                 self.db.record_prereq(f"NPU device in {slot} missing driver", "🚦")
                 self.failures += [MissingDriver(slot)]
-                return False
             p = os.path.join(device.sys_path, "fw_version")
             if os.path.exists(p):
                 xdna_fw_version = read_file(p)


### PR DESCRIPTION
They are only fatal if the driver loaded but didn't bind (due to a problem). So just add some messaging about a missing driver and warning if it didn't load.