### PR TITLE
amd_s2idle: Robustify RTC selection for wakealarm

### DIFF
--- a/src/amd_debug/validator.py
+++ b/src/amd_debug/validator.py
@@ -693,7 +693,10 @@ class SleepValidator(AmdTool):
         """Program the RTC wakealarm to wake the system after the requested duration"""
         wakealarm = None
         for device in self.pyudev.list_devices(subsystem="rtc"):
-            wakealarm = os.path.join(device.sys_path, "wakealarm")
+            target = os.path.join(device.sys_path, "wakealarm")
+            if os.path.exists(target):
+                wakealarm = target
+                break
         if wakealarm:
             with open(wakealarm, "w", encoding="utf-8") as w:
                 w.write("0")


### PR DESCRIPTION
Currently, program_wakealarm() iterates through all RTC devices and unconditionally selects the last one found. This is problematic on platforms where multiple RTC interfaces exist but not all support wake alarms.

Specifically, commit kernel v7.0-rc1-16-g8a1e7f4b1764 ("ACPI: TAD: Add RTC class device interface") introduces an ACPI TAD RTC that provides timekeeping but may lack wakealarm support. On systems where this device is probed after the legacy CMOS RTC, the script attempts to use the TAD sysfs path, finds no 'wakealarm' file, and fails.

Modify the selection logic to:
1. Check for the existence of the 'wakealarm' file before selection.
2. Break the loop once a valid RTC device is found to avoid overwriting a functional device with a non-functional one.