### PR TITLE
Fix Python 3.14 crash in reboot() — replace deprecated asyncio.get_event_loop()

### DIFF
--- a/src/amd_debug/common.py
+++ b/src/amd_debug/common.py
@@ -273,8 +273,7 @@ def reboot():
             return False
         return True
 
-    loop = asyncio.get_event_loop()
-    result = loop.run_until_complete(reboot_dbus_fast())
+    result = asyncio.run(reboot_dbus_fast())
     if not result:
         return reboot_dbus()
 

--- a/src/test_common.py
+++ b/src/test_common.py
@@ -530,43 +530,16 @@ class TestCommon(unittest.TestCase):
         self.assertAlmostEqual(get_system_mem(), expected_gb)
         mock_file.assert_called_once_with("/proc/meminfo", "r", encoding="utf-8")
 
-    def test_reboot_dbus_fast_success(self):
+    @patch("amd_debug.common.asyncio.run", return_value=True)
+    def test_reboot_dbus_fast_success(self, mock_asyncio_run):
         """Test reboot returns True when reboot_dbus_fast succeeds"""
+        result = reboot()
+        self.assertTrue(result)
+        mock_asyncio_run.assert_called_once()
 
-        # Create a mock loop that properly handles coroutines
-        def mock_run_until_complete(coro):
-            # Consume the coroutine to prevent the warning
-            try:
-                # Close the coroutine to prevent the warning
-                coro.close()
-            except (AttributeError, RuntimeError):
-                pass
-            return True
-
-        mock_loop = Mock()
-        mock_loop.run_until_complete.side_effect = mock_run_until_complete
-
-        with patch("amd_debug.common.asyncio.get_event_loop", return_value=mock_loop):
-            result = reboot()
-            self.assertTrue(result)
-            mock_loop.run_until_complete.assert_called_once()
-
-    @patch("asyncio.get_event_loop")
-    def test_reboot_dbus_fast_failure_and_dbus_success(self, mock_get_event_loop):
+    @patch("amd_debug.common.asyncio.run", return_value=False)
+    def test_reboot_dbus_fast_failure_and_dbus_success(self, mock_asyncio_run):
         """Test reboot falls back to reboot_dbus when reboot_dbus_fast fails"""
-
-        # Create a mock loop that properly handles coroutines
-        def mock_run_until_complete(coro):
-            # Consume the coroutine to prevent the warning
-            try:
-                coro.close()
-            except (AttributeError, RuntimeError):
-                pass
-            return False
-
-        mock_loop = Mock()
-        mock_loop.run_until_complete.side_effect = mock_run_until_complete
-        mock_get_event_loop.return_value = mock_loop
 
         # Mock the dbus module to avoid ImportError in CI
         mock_dbus = Mock()
@@ -583,22 +556,9 @@ class TestCommon(unittest.TestCase):
             result = reboot()
             self.assertTrue(result)
 
-    @patch("asyncio.get_event_loop")
-    def test_reboot_dbus_fast_failure_and_dbus_failure(self, mock_get_event_loop):
+    @patch("amd_debug.common.asyncio.run", return_value=False)
+    def test_reboot_dbus_fast_failure_and_dbus_failure(self, mock_asyncio_run):
         """Test reboot returns False when both reboot_dbus_fast and reboot_dbus fail"""
-
-        # Create a mock loop that properly handles coroutines
-        def mock_run_until_complete(coro):
-            # Consume the coroutine to prevent the warning
-            try:
-                coro.close()
-            except (AttributeError, RuntimeError):
-                pass
-            return False
-
-        mock_loop = Mock()
-        mock_loop.run_until_complete.side_effect = mock_run_until_complete
-        mock_get_event_loop.return_value = mock_loop
 
         # Mock the import to raise ImportError when dbus is imported
         original_import = builtins.__import__


### PR DESCRIPTION
## Summary

- `amd-ttm --set` (and any tool calling `reboot()`) crashes on Python 3.14 with `RuntimeError: There is no current event loop in thread 'MainThread'` - Python 3.14 deprecates `asyncio.get_event_loop()` 
- Replace `get_event_loop()` + `run_until_complete()` with `asyncio.run()`, which works on all Python >= 3.7

Fixes: ROCm/ROCm#6254

## Changes

```python
# Before (line 276):
loop = asyncio.get_event_loop()
result = loop.run_until_complete(reboot_dbus_fast())

# After:
result = asyncio.run(reboot_dbus_fast())
```

Also update 3 test cases to mock newly added `asyncio.run`.

## Test plan

Reproduced and verified in a Python 3.14.5 venv.

**Before fix:**
```
$ python -c "from amd_debug.common import reboot; reboot()"
RuntimeError: There is no current event loop in thread 'MainThread'.
```

**After fix:**
```
$ python -c "from amd_debug.common import reboot; reboot()"
# Returns True and succesfully reboots.
```

**Unit tests:** 38/38 pass on Python 3.14.5:
```
src/test_common.py::TestCommon::test_reboot_dbus_fast_success PASSED
src/test_common.py::TestCommon::test_reboot_dbus_fast_failure_and_dbus_success PASSED
src/test_common.py::TestCommon::test_reboot_dbus_fast_failure_and_dbus_failure PASSED
======================== 38 passed in 2.08s ========================
```
