### PR TITLE
Pass KDE_SESSION_VERSION to xdg-open

### DIFF
--- a/src/amd_debug/common.py
+++ b/src/amd_debug/common.py
@@ -422,6 +422,7 @@ def relaunch_sudo() -> None:
             "DBUS_SESSION_BUS_ADDRESS",
             "XDG_SESSION_TYPE",
             "XDG_DATA_DIRS",
+            "KDE_SESSION_VERSION",
             "SSH_CLIENT",
             "SSH_TTY"
         ]:

--- a/src/amd_debug/s2idle.py
+++ b/src/amd_debug/s2idle.py
@@ -62,7 +62,7 @@ def display_report_file(fname, fmt) -> None:
     if user:
         env_vars = []
         for var in ["DISPLAY", "WAYLAND_DISPLAY", "XAUTHORITY", "XDG_RUNTIME_DIR",
-                    "DBUS_SESSION_BUS_ADDRESS", "XDG_SESSION_TYPE", "XDG_DATA_DIRS"]:
+                    "DBUS_SESSION_BUS_ADDRESS", "XDG_SESSION_TYPE", "XDG_DATA_DIRS", "KDE_SESSION_VERSION"]:
             value = os.environ.get(var)
             if value:
                 env_vars.append(f"{var}={value}")


### PR DESCRIPTION
The latest xdg-open implementation in Manjaro requires KDE_SESSION_VERSION env. 
Otherwise throws errors like
`/usr/bin/xdg-open: line 757: kfmclient: command not found`