### PR TITLE
amd-s2idle: Drop group-writable /var/local database fallback

### DIFF
--- a/src/amd_debug/database.py
+++ b/src/amd_debug/database.py
@@ -44,12 +44,8 @@ class SleepDatabase:
         self.debug_cnt = 0
 
         if not dbf:
-            # if we were packaged we would have a directory in /var/lib
             path = os.path.join("/", "var", "lib", "amd-s2idle")
-            if not os.path.exists(path):
-                path = os.path.join("/", "var", "local", "lib", "amd-s2idle")
-            os.makedirs(path, exist_ok=True)
-
+            os.makedirs(path, mode=0o700, exist_ok=True)
             dbf = os.path.join(path, "data.db")
         new = not os.path.exists(dbf)
         self.db = sqlite3.connect(dbf)

--- a/src/test_database.py
+++ b/src/test_database.py
@@ -7,6 +7,7 @@ This module contains unit tests for the datbase functions in the amd-debug-tools
 import unittest
 
 from datetime import datetime
+from unittest.mock import patch, MagicMock
 
 from amd_debug.database import SleepDatabase
 
@@ -363,6 +364,23 @@ class TestSleepDatabase(unittest.TestCase):
         self.db.start_cycle(timestamp)
         result = self.db.report_power_rails(timestamp)
         self.assertEqual(result, [])
+
+    def test_default_db_path_uses_var_lib_restrictive(self):
+        """Test the default database path is created securely in /var/lib"""
+        with patch("amd_debug.database.os.makedirs") as makedirs, patch(
+            "amd_debug.database.os.path.exists", return_value=False
+        ), patch("amd_debug.database.sqlite3.connect", return_value=MagicMock()):
+            SleepDatabase()
+
+            # Directory is created in /var/lib with a restrictive mode
+            makedirs.assert_called_once_with(
+                "/var/lib/amd-s2idle", mode=0o700, exist_ok=True
+            )
+
+            # The insecure /var/local fallback is never referenced
+            for call in makedirs.call_args_list:
+                for arg in call.args:
+                    self.assertNotIn("/var/local", str(arg))
 
     def test_schema_migration_v1_to_v2(self):
         """Test database migration from schema v1 to v2"""


### PR DESCRIPTION
The sleep database location previously fell back to `/var/local/lib/amd-s2idle` when `/var/lib/amd-s2idle` did not exist. On Debian-derived systems `/var/local` is group-staff writable (mode 2775), which would let a non-root user in the staff group pre-plant a poisoned `data.db` or a symlink there; the root systemd sleep hook would then open that attacker-controlled file.

Always use `/var/lib/amd-s2idle` and create it with a restrictive `0o700` mode. The tool runs as root when it needs this path, so no fallback is required.

Adds a regression test asserting the default DB path targets `/var/lib/amd-s2idle` at mode 0700 and never `/var/local`.

Full test suite passes (`pytest src`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)