### PR TITLE
amd-s2idle: Validate firmware-supplied trace format strings

### DIFF
--- a/src/amd_debug/kernel.py
+++ b/src/amd_debug/kernel.py
@@ -128,6 +128,13 @@ def sscanf_bios_args(line):
                 else:
                     break
 
+            # Reject unexpected conversions or oversized field widths from
+            # untrusted firmware-supplied format strings.
+            if re.search(r"%(?![xXdD%])", format_string) or re.search(
+                r"%\d{4,}", format_string
+            ):
+                return None
+
             try:
                 return format_string % tuple(converted_args)
             except TypeError:

--- a/src/test_kernel.py
+++ b/src/test_kernel.py
@@ -338,6 +338,21 @@ class TestSscanfBiosArgsEdge(unittest.TestCase):
         """ev_queue_notify_reques without ': ' returns None"""
         self.assertIsNone(sscanf_bios_args("ev_queue_notify_reques nothing"))
 
+    def test_ex_trace_args_oversized_width(self):
+        """An oversized field width is rejected instead of allocating memory"""
+        line = 'ex_trace_args: "%2147483646d", 1, 0, 0, 0, 0, 0'
+        self.assertIsNone(sscanf_bios_args(line))
+
+    def test_ex_trace_args_unexpected_conversion(self):
+        """A conversion outside the whitelist is rejected"""
+        line = 'ex_trace_args: "value: %s", 1, 0, 0, 0, 0, 0'
+        self.assertIsNone(sscanf_bios_args(line))
+
+    def test_ex_trace_args_valid_conversion(self):
+        """A whitelisted conversion is still applied normally"""
+        line = 'ex_trace_args: "%x", 1234'
+        self.assertEqual(sscanf_bios_args(line), "1234")
+
 
 class TestGetKernelLog(unittest.TestCase):
     """Test get_kernel_log provider selection"""


### PR DESCRIPTION
The format string extracted from an ACPI `ex_trace_args` kernel-log line is supplied by BIOS AML and applied directly with Python's `%` operator. Only the `%x`/`%X`/`%d`/`%D` specifiers were counted, but every conversion in the string was still interpreted. A malformed or hostile firmware could use this to force a huge string allocation (for example `%2147483646d`) or to mangle output with mismatched specifiers such as `%s` or `%c`.

Reject any format string that contains a conversion outside the expected `%x`/`%X`/`%d`/`%D` whitelist (or an oversized field width) before applying it. Adds regression tests covering these cases.

Full test suite passes (`pytest src`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)