### PR TITLE
amd-s2idle: Redact sensitive data from captured kernel log

### DIFF
--- a/src/amd_debug/kernel.py
+++ b/src/amd_debug/kernel.py
@@ -94,6 +94,30 @@ def get_kernel_command_line() -> str:
     return " ".join([x for x in cmdline.split() if not x.startswith(tuple(filtered))])
 
 
+def redact_sensitive(text: str) -> str:
+    """Redact high-confidence sensitive tokens from captured log text.
+
+    Only obviously-sensitive patterns are scrubbed so that the remaining
+    content keeps its diagnostic value:
+      - MAC addresses
+      - UUIDs (e.g. LUKS/filesystem identifiers)
+      - key/secret/password/token assignments
+    """
+    text = re.sub(r"([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}", "<redacted-mac>", text)
+    text = re.sub(
+        r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+        r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
+        "<redacted-uuid>",
+        text,
+    )
+    text = re.sub(
+        r"(?i)\b(key|secret|password|passwd|token)=\S+",
+        r"\1=<redacted>",
+        text,
+    )
+    return text
+
+
 def sscanf_bios_args(line):
     """Extracts the format string and arguments from a BIOS trace line"""
     if re.search(r"ex_trace_point", line):

--- a/src/amd_debug/prerequisites.py
+++ b/src/amd_debug/prerequisites.py
@@ -20,7 +20,13 @@ import pyudev
 
 from amd_debug.wake import WakeIRQ
 from amd_debug.display import Display
-from amd_debug.kernel import get_kernel_log, SystemdLogger, CySystemdLogger, DmesgLogger
+from amd_debug.kernel import (
+    get_kernel_log,
+    redact_sensitive,
+    SystemdLogger,
+    CySystemdLogger,
+    DmesgLogger,
+)
 from amd_debug.common import (
     apply_prefix_wrapper,
     BIT,
@@ -1451,7 +1457,7 @@ class PrerequisiteValidator(AmdTool):
                 result = False
         if not result:
             self.db.record_prereq(Headers.BrokenPrerequisites, "🚫")
-            self.db.record_debug(self.kernel_log.get_full_log())
+            self.db.record_debug(redact_sensitive(self.kernel_log.get_full_log()))
         self.db.sync()
         clear_temporary_message(len(msg))
         return result

--- a/src/test_kernel.py
+++ b/src/test_kernel.py
@@ -14,6 +14,7 @@ import logging
 from amd_debug.kernel import (
     sscanf_bios_args,
     get_kernel_command_line,
+    redact_sensitive,
     DmesgLogger,
     InputFile,
     KernelLogger,
@@ -66,6 +67,31 @@ class TestKernelLog(unittest.TestCase):
         ) as _mock_file:
             result = get_kernel_command_line()
             self.assertEqual(result, expected_output)
+
+    def test_redact_sensitive(self):
+        """Test redact_sensitive function"""
+
+        # MAC addresses are redacted
+        result = redact_sensitive("wlan0: link up 00:11:22:33:44:55 detected")
+        self.assertEqual(result, "wlan0: link up <redacted-mac> detected")
+
+        # UUIDs are redacted
+        result = redact_sensitive(
+            "cryptsetup: 12345678-90ab-cdef-1234-567890abcdef mounted"
+        )
+        self.assertEqual(result, "cryptsetup: <redacted-uuid> mounted")
+
+        # key/secret/password/token assignments are redacted
+        self.assertEqual(
+            redact_sensitive("luks key=abcd1234"), "luks key=<redacted>"
+        )
+        self.assertEqual(
+            redact_sensitive("token=deadbeef"), "token=<redacted>"
+        )
+
+        # Ordinary log text is preserved
+        line = "amd_pmc AMDI0009:00: SMU idlemask s0i3: 0x1234abcd"
+        self.assertEqual(redact_sensitive(line), line)
 
     def test_sscanf_bios_args(self):
         """Test sscanf_bios_args function"""


### PR DESCRIPTION
When a prerequisite check fails the full journald/dmesg buffer is stored in the report. The kernel log can contain identifiers such as LUKS/filesystem UUIDs, network MAC addresses, and key/token assignments, which would then be exposed to any local user able to read the report.

Add a conservative `redact_sensitive()` helper that scrubs only high-confidence sensitive tokens (MAC addresses, UUIDs, and key/secret/password/token assignments) while preserving the diagnostic value of the rest of the log, and apply it before recording the log. Adds regression tests for the helper.

Full test suite passes (`pytest src`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)