### PR TITLE
amd-s2idle: Load kernel modules via absolute path without a shell

### DIFF
--- a/src/amd_debug/common.py
+++ b/src/amd_debug/common.py
@@ -394,7 +394,7 @@ def read_msr(msr, cpu):
     """Read a Model-Specific Register (MSR) value from the CPU."""
     p = f"/dev/cpu/{cpu}/msr"
     if not os.path.exists(p) and is_root():
-        os.system("modprobe msr")
+        subprocess.run(["/sbin/modprobe", "msr"], check=False)
     try:
         f = os.open(p, os.O_RDONLY)
     except OSError as exc:

--- a/src/amd_debug/prerequisites.py
+++ b/src/amd_debug/prerequisites.py
@@ -1177,7 +1177,7 @@ class PrerequisiteValidator(AmdTool):
             """Read CPUID using kernel userspace interface"""
             p = os.path.join("/", "dev", "cpu", f"{cpu}", "cpuid")
             if not os.path.exists(p):
-                os.system("modprobe cpuid")
+                subprocess.run(["/sbin/modprobe", "cpuid"], check=False)
             with open(p, "rb") as f:
                 position = (subleaf << 32) | leaf
                 f.seek(position)

--- a/src/test_common.py
+++ b/src/test_common.py
@@ -34,6 +34,7 @@ from amd_debug.common import (
     is_root,
     minimum_kernel,
     print_color,
+    read_msr,
     reboot,
     run_countdown,
     systemd_in_use,
@@ -232,6 +233,21 @@ class TestCommon(unittest.TestCase):
         self.assertFalse(is_root())
         mock_geteuid.assert_called_once()
         self.assertEqual(mock_geteuid.call_count, 1)
+
+    @patch("amd_debug.common.os.open", side_effect=OSError)
+    @patch("amd_debug.common.subprocess.run")
+    @patch("amd_debug.common.is_root", return_value=True)
+    @patch("amd_debug.common.os.path.exists", return_value=False)
+    def test_read_msr_loads_module(
+        self, mock_exists, mock_is_root, mock_run, mock_open_fd
+    ):
+        """Test read_msr loads the msr module via an absolute path and no shell"""
+        with self.assertRaises(PermissionError):
+            read_msr(0xC0010292, 0)
+        mock_run.assert_called_once_with(["/sbin/modprobe", "msr"], check=False)
+        # ensure the module load never went through a shell
+        _, kwargs = mock_run.call_args
+        self.assertNotIn("shell", kwargs)
 
     def test_get_log_priority(self):
         """Test get_log_priority works for expected values"""

--- a/src/test_prerequisites.py
+++ b/src/test_prerequisites.py
@@ -717,6 +717,31 @@ class TestPrerequisiteValidator(unittest.TestCase):
             "Unable to check CPU topology: cpuid kernel module not loaded", "❌"
         )
 
+    @patch("amd_debug.prerequisites.subprocess.run")
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("amd_debug.prerequisites.read_file")
+    @patch("amd_debug.prerequisites.os.path.exists")
+    def test_check_cpu_loads_cpuid_module(
+        self, mock_path_exists, mock_read_file, mock_file_open, mock_run
+    ):
+        """Test read_cpuid loads the cpuid module via an absolute path and no shell"""
+        self.validator.cpu_family = 0x19
+        self.validator.cpu_model = 0x74
+        mock_read_file.return_value = "31"  # kernel_max = 31 (32 cores)
+        # cpuid device node missing so the module load path is exercised
+        mock_path_exists.return_value = False
+        mock_file_open.return_value.read.side_effect = [
+            struct.pack("4I", 0, 0, 0x100, 0),  # subleaf 0: level_type = 1
+            struct.pack("4I", 0, 0, 0x400, 0),  # subleaf 1: level_type = 4 (socket)
+            struct.pack("4I", 0, 16, 0, 0),  # subleaf 1: cpu_count = 16
+        ]
+        result = self.validator.check_cpu()
+        self.assertTrue(result)
+        mock_run.assert_any_call(["/sbin/modprobe", "cpuid"], check=False)
+        # ensure the module load never went through a shell
+        for _, kwargs in mock_run.call_args_list:
+            self.assertNotIn("shell", kwargs)
+
     @patch("builtins.open", side_effect=PermissionError)
     @patch("amd_debug.prerequisites.read_file")
     @patch("amd_debug.prerequisites.os.path.exists")


### PR DESCRIPTION
Loading the `msr` and `cpuid` kernel modules went through `os.system()`, which runs `/bin/sh -c` and resolves `modprobe` via `$PATH`. When the tool runs as root with an untrusted PATH, that allows an attacker-controlled binary to be executed. Invoke modprobe directly with `subprocess.run()` using an absolute path and no shell.

Adds regression tests asserting both call sites invoke `["/sbin/modprobe", ...]` with no shell.

Full test suite passes (`pytest src`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)