### PR TITLE
amd-s2idle: Sanitise IRQ action name before walking sysfs

### DIFF
--- a/src/amd_debug/wake.py
+++ b/src/amd_debug/wake.py
@@ -75,29 +75,36 @@ class WakeIRQ:
 
         # "might" look like an ACPI device, try to follow it
         if not self.name and self.actions:
-            p = os.path.join("/", "sys", "bus", "acpi", "devices", self.actions)
-            if os.path.exists(p):
-                for directory in os.listdir(p):
-                    if "physical_node" not in directory:
-                        continue
+            # self.actions is a free-form string supplied to request_irq() by
+            # the kernel, so restrict it to a single path component to avoid
+            # escaping the ACPI device directory via "/" or "..".
+            comp = os.path.basename(self.actions)
+            if comp and comp not in (".", ".."):
+                p = os.path.join("/", "sys", "bus", "acpi", "devices", comp)
+                if os.path.exists(p):
+                    for directory in os.listdir(p):
+                        if "physical_node" not in directory:
+                            continue
 
-                    for root, _dirs, files in os.walk(
-                        os.path.join(p, directory), followlinks=True
-                    ):
-                        if "name" in files:
-                            try:
-                                self.name = read_file(os.path.join(root, "name"))
-                            except (PermissionError, FileNotFoundError):
-                                pass
-                            t = os.path.join(root, "driver")
-                            if os.path.exists(t):
+                        for root, _dirs, files in os.walk(
+                            os.path.join(p, directory), followlinks=False
+                        ):
+                            if "name" in files:
                                 try:
-                                    self.driver = os.path.basename(os.readlink(t))
-                                except (PermissionError, FileNotFoundError, OSError):
+                                    self.name = read_file(os.path.join(root, "name"))
+                                except (PermissionError, FileNotFoundError):
                                     pass
+                                t = os.path.join(root, "driver")
+                                if os.path.exists(t):
+                                    try:
+                                        self.driver = os.path.basename(
+                                            os.readlink(t)
+                                        )
+                                    except (PermissionError, FileNotFoundError, OSError):
+                                        pass
+                                break
+                        if self.name:
                             break
-                    if self.name:
-                        break
 
         # If the name isn't descriptive try to guess further
         if self.driver and self.actions == self.name:

--- a/src/test_wake.py
+++ b/src/test_wake.py
@@ -492,6 +492,42 @@ class TestWakeIRQ(unittest.TestCase):
         irq = WakeIRQ(80)
         self.assertEqual(irq.name, "")
 
+    @patch("amd_debug.wake.read_file")
+    @patch("os.path.exists")
+    @patch("os.listdir")
+    @patch("os.walk")
+    def test_wake_irq_acpi_path_traversal(
+        self, mock_os_walk, mock_os_listdir, mock_os_path_exists, mock_read_file
+    ):
+        """A traversal sequence in actions must not escape the ACPI device dir"""
+        mock_read_file.side_effect = lambda path: {
+            "/sys/kernel/irq/82/chip_name": "",
+            "/sys/kernel/irq/82/actions": "../../foo",
+            "/sys/kernel/irq/82/wakeup": "enabled",
+        }.get(path, "")
+
+        checked = []
+
+        def exists_side_effect(path):
+            checked.append(path)
+            return False
+
+        mock_os_path_exists.side_effect = exists_side_effect
+
+        irq = WakeIRQ(82)
+
+        # The action name must be reduced to its basename before being joined
+        # under the ACPI devices directory, so no ".." component is ever used.
+        acpi_checks = [
+            p for p in checked if p.startswith("/sys/bus/acpi/devices")
+        ]
+        self.assertIn("/sys/bus/acpi/devices/foo", acpi_checks)
+        for p in acpi_checks:
+            self.assertNotIn("..", p)
+        # os.walk must never run since the sanitised path does not exist.
+        mock_os_walk.assert_not_called()
+        self.assertEqual(irq.name, "")
+
     def test_wake_irq_str(self):
         """Test __str__ of WakeIRQ"""
         with patch("amd_debug.wake.read_file", side_effect=FileNotFoundError()), \


### PR DESCRIPTION
The IRQ action name is a free-form string supplied to `request_irq()` by the kernel and was joined directly under `/sys/bus/acpi/devices/` before being recursed with `os.walk()`. A name containing path separators or `..` could redirect the walk outside the intended directory, and following symlinks during that walk could lead to very deep or cyclic traversal.

Reduce the action name to a single path component with `os.path.basename()` and reject empty, `.` and `..` values before use, and stop following symlinks while walking the resulting directory. Adds regression tests.

Full test suite passes (`pytest src`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)